### PR TITLE
Skip steps if commands are missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: seeker
 Type: Package
 Title: Process genomic data
-Version: 0.0.0.9052
+Version: 0.0.0.9053
 Authors@R: as.person("Jake Hughey <jakejhughey@gmail.com> [aut, cre]")
 Description: Simplified processing of sequencing and microarray data.
 URL: https://seeker.hugheylab.org, https://github.com/hugheylab/seeker

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -12,7 +12,7 @@ snapshot = function(xObs, path) {
 
 getCommandsCheck = function(params, cmds = checkDefaultCommands()) {
   result = foreach(i = 1:nrow(cmds), .combine = rbind) %do% {
-    cmdRow = cmds[i,]
+    cmdRow = cmds[i]
     cmd = if (cmdRow$command == 'ascp') {
       params$fetch$ascpCmd
     } else if (cmdRow$command == 'trim_galore') {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -22,8 +22,8 @@ getCommandsCheck = function(params, cmds = checkDefaultCommands()) {
     } else {
       NULL}
 
-    cmdExists = !((is.null(cmd) & is.na(cmdRow$path)) |
-                  (!is.null(cmd) & is.na(checkCommand(cmd))))
+    cmdExists = !((is.null(cmd) && is.na(cmdRow$path)) ||
+                  (!is.null(cmd) && is.na(checkCommand(cmd))))
     data.table(filename = cmdRow$command, exists = cmdExists)}
   return(result)}
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,8 +10,8 @@ snapshot = function(xObs, path) {
     xExp = xObs}
   return(xExp)}
 
-commandsExists = function(params, cmds = seeker:::checkDefaultCommands()) {
-  exists = foreach(i = 1:nrow(cmds), .combine = rbind) %do% {
+getCommandsCheck = function(params, cmds = seeker:::checkDefaultCommands()) {
+  result = foreach(i = 1:nrow(cmds), .combine = rbind) %do% {
     cmdRow = cmds[i,]
     cmd = if (cmdRow$command == 'ascp') {
       params$fetch$ascpCmd
@@ -31,7 +31,7 @@ commandsExists = function(params, cmds = seeker:::checkDefaultCommands()) {
         cmdExists = FALSE}}
     cmdRow[, exists := cmdExists]
   }
-  return(exists)}
+  return(result)}
 
 registerDoSEQ()
 dataDir = 'data'
@@ -45,8 +45,8 @@ if (Sys.info()['user'] != 'runner') {
                                 paste0('/', Sys.info()['user'], '/'),
                                 params$salmon$indexDir)}
 
-missingCommands = rbind(commandsExists(params), data.table(command = 'samlmon_index', path = params$salmon$indexDir, exists = file.exists(params$salmon$indexDir)), fill = TRUE)
-anyMissing = any(!missingCommands[['exists']])
+commandsDt = rbind(getCommandsCheck(params), data.table(command = 'salmon_index', path = params$salmon$indexDir, exists = file.exists(params$salmon$indexDir)), fill = TRUE)
+anyMissing = any(!commandsDt[['exists']])
 
 
 params$fetch$run = FALSE

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -12,7 +12,7 @@ snapshot = function(xObs, path) {
 
 getCommandsCheck = function(params, cmds = checkDefaultCommands()) {
   result = foreach(i = 1:nrow(cmds), .combine = rbind) %do% {
-    cmdRow = cmds[i]
+    cmdRow = cmds[i,]
     cmd = if (cmdRow$command == 'ascp') {
       params$fetch$ascpCmd
     } else if (cmdRow$command == 'trim_galore') {
@@ -39,9 +39,9 @@ if (Sys.info()['user'] != 'runner') {
                                 paste0('/', Sys.info()['user'], '/'),
                                 params$salmon$indexDir)}
 
-commandsDt = rbind(getCommandsCheck(params),
-                   data.table(filename = 'salmon_index',
-                              exists = file.exists(params$salmon$indexDir)))
+commandsDt = rbind(
+  getCommandsCheck(params),
+  data.table(filename = 'salmon_index', exists = file.exists(params$salmon$indexDir)))
 anyMissing = any(!commandsDt[['exists']])
 
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,6 +10,29 @@ snapshot = function(xObs, path) {
     xExp = xObs}
   return(xExp)}
 
+commandsExists = function(params, cmds = seeker:::checkDefaultCommands()) {
+  exists = foreach(i = 1:nrow(cmds), .combine = rbind) %do% {
+    cmdRow = cmds[i,]
+    cmd = if (cmdRow$command == 'ascp') {
+      params$fetch$ascpCmd
+    } else if (cmdRow$command == 'trim_galore') {
+      params$trimgalore$cmd
+    } else if (cmdRow$command %in% names(params)) {
+      params[[cmdRow$command]]$cmd
+    } else {
+      NULL}
+    cmdExists = TRUE
+    if (is.null(cmd)) {
+      if (is.na(cmdRow$path)) {
+        cmdExists = FALSE}
+    } else {
+      path = checkCommand(cmd)
+      if (is.na(path)) {
+        cmdExists = FALSE}}
+    cmdRow[, exists := cmdExists]
+  }
+  return(exists)}
+
 registerDoSEQ()
 dataDir = 'data'
 params = yaml::read_yaml(file.path(dataDir, 'GSE143524.yml'))
@@ -21,6 +44,10 @@ if (Sys.info()['user'] != 'runner') {
   params$salmon$indexDir = gsub('/runner/',
                                 paste0('/', Sys.info()['user'], '/'),
                                 params$salmon$indexDir)}
+
+missingCommands = rbind(commandsExists(params), data.table(command = 'samlmon_index', path = params$salmon$indexDir, exists = file.exists(params$salmon$indexDir)), fill = TRUE)
+anyMissing = any(!missingCommands[['exists']])
+
 
 params$fetch$run = FALSE
 parentDir = file.path(dataDir, 'staging')

--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -25,7 +25,7 @@ test_that('fetchMetadata', {
 
 test_that('fetch', {
   skip("Skipping until aspera command error can be pinned down/solved")
-  skip_if(!missingCommands[command == 'ascp',]$exists, 'Missing ascp command, skipping.')
+  skip_if(!commandsDt[command == 'ascp',]$exists, 'Missing ascp command, skipping.')
   skip_on_os('windows', arch = NULL)
   outputDirFetchTest = file.path(parentDir, 'GSM5694054')
   if (!dir.exists(outputDirFetchTest)) dir.create(outputDirFetchTest)

--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -25,6 +25,7 @@ test_that('fetchMetadata', {
 
 test_that('fetch', {
   skip("Skipping until aspera command error can be pinned down/solved")
+  skip_if(!missingCommands[command == 'ascp',]$exists, 'Missing ascp command, skipping.')
   skip_on_os('windows', arch = NULL)
   outputDirFetchTest = file.path(parentDir, 'GSM5694054')
   if (!dir.exists(outputDirFetchTest)) dir.create(outputDirFetchTest)

--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -25,7 +25,7 @@ test_that('fetchMetadata', {
 
 test_that('fetch', {
   skip("Skipping until aspera command error can be pinned down/solved")
-  skip_if(!commandsDt[filename == 'ascp',]$exists, 'Missing ascp command, skipping.')
+  skip_if(!commandsDt[filename == 'ascp']$exists, 'Missing ascp command, skipping.')
   skip_on_os('windows', arch = NULL)
   outputDirFetchTest = file.path(parentDir, 'GSM5694054')
   if (!dir.exists(outputDirFetchTest)) dir.create(outputDirFetchTest)

--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -25,7 +25,7 @@ test_that('fetchMetadata', {
 
 test_that('fetch', {
   skip("Skipping until aspera command error can be pinned down/solved")
-  skip_if(!commandsDt[command == 'ascp',]$exists, 'Missing ascp command, skipping.')
+  skip_if(!commandsDt[filename == 'ascp',]$exists, 'Missing ascp command, skipping.')
   skip_on_os('windows', arch = NULL)
   outputDirFetchTest = file.path(parentDir, 'GSM5694054')
   if (!dir.exists(outputDirFetchTest)) dir.create(outputDirFetchTest)

--- a/tests/testthat/test-qc.R
+++ b/tests/testthat/test-qc.R
@@ -1,5 +1,5 @@
 test_that('fastqc', {
-  skip_if(!missingCommands[command == 'fastqc',]$exists, 'Missing fastqc command, skipping.')
+  skip_if(!commandsDt[command == 'fastqc',]$exists, 'Missing fastqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'fastqc'
   paramsNow = params[[step]]
@@ -17,7 +17,7 @@ test_that('fastqc', {
 })
 
 test_that('trimgalore', {
-  skip_if(!missingCommands[command == 'trim_galore',]$exists, 'Missing trim_galore command, skipping.')
+  skip_if(!commandsDt[command == 'trim_galore',]$exists, 'Missing trim_galore command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'trimgalore'
   paramsNow = params[[step]]
@@ -35,7 +35,7 @@ test_that('trimgalore', {
 })
 
 test_that('multiqc', {
-  skip_if(!missingCommands[command == 'multiqc',]$exists, 'Missing multiqc command, skipping.')
+  skip_if(!commandsDt[command == 'multiqc',]$exists, 'Missing multiqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'multiqc'
 

--- a/tests/testthat/test-qc.R
+++ b/tests/testthat/test-qc.R
@@ -1,4 +1,5 @@
 test_that('fastqc', {
+  skip_if(!missingCommands[command == 'fastqc',]$exists, 'Missing fastqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'fastqc'
   paramsNow = params[[step]]
@@ -16,6 +17,7 @@ test_that('fastqc', {
 })
 
 test_that('trimgalore', {
+  skip_if(!missingCommands[command == 'trim_galore',]$exists, 'Missing trim_galore command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'trimgalore'
   paramsNow = params[[step]]
@@ -33,6 +35,7 @@ test_that('trimgalore', {
 })
 
 test_that('multiqc', {
+  skip_if(!missingCommands[command == 'multiqc',]$exists, 'Missing multiqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'multiqc'
 

--- a/tests/testthat/test-qc.R
+++ b/tests/testthat/test-qc.R
@@ -1,5 +1,5 @@
 test_that('fastqc', {
-  skip_if(!commandsDt[command == 'fastqc',]$exists, 'Missing fastqc command, skipping.')
+  skip_if(!commandsDt[filename == 'fastqc',]$exists, 'Missing fastqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'fastqc'
   paramsNow = params[[step]]
@@ -17,7 +17,7 @@ test_that('fastqc', {
 })
 
 test_that('trimgalore', {
-  skip_if(!commandsDt[command == 'trim_galore',]$exists, 'Missing trim_galore command, skipping.')
+  skip_if(!commandsDt[filename == 'trim_galore',]$exists, 'Missing trim_galore command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'trimgalore'
   paramsNow = params[[step]]
@@ -35,7 +35,7 @@ test_that('trimgalore', {
 })
 
 test_that('multiqc', {
-  skip_if(!commandsDt[command == 'multiqc',]$exists, 'Missing multiqc command, skipping.')
+  skip_if(!commandsDt[filename == 'multiqc',]$exists, 'Missing multiqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'multiqc'
 

--- a/tests/testthat/test-qc.R
+++ b/tests/testthat/test-qc.R
@@ -1,5 +1,5 @@
 test_that('fastqc', {
-  skip_if(!commandsDt[filename == 'fastqc',]$exists, 'Missing fastqc command, skipping.')
+  skip_if(!commandsDt[filename == 'fastqc']$exists, 'Missing fastqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'fastqc'
   paramsNow = params[[step]]
@@ -17,7 +17,7 @@ test_that('fastqc', {
 })
 
 test_that('trimgalore', {
-  skip_if(!commandsDt[filename == 'trim_galore',]$exists, 'Missing trim_galore command, skipping.')
+  skip_if(!commandsDt[filename == 'trim_galore']$exists, 'Missing trim_galore command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'trimgalore'
   paramsNow = params[[step]]
@@ -35,7 +35,7 @@ test_that('trimgalore', {
 })
 
 test_that('multiqc', {
-  skip_if(!commandsDt[filename == 'multiqc',]$exists, 'Missing multiqc command, skipping.')
+  skip_if(!commandsDt[filename == 'multiqc']$exists, 'Missing multiqc command, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'multiqc'
 

--- a/tests/testthat/test-salmon.R
+++ b/tests/testthat/test-salmon.R
@@ -1,5 +1,5 @@
 test_that('salmon and getSalmonMetadata', {
-  skip_if((!missingCommands[command == 'salmon',]$exists | !missingCommands[command == 'salmon_index',]$exists), 'Missing salmon command and/or index, skipping.')
+  skip_if((!commandsDt[command == 'salmon',]$exists | !commandsDt[command == 'salmon_index',]$exists), 'Missing salmon command and/or index, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'salmon'
   paramsNow = params[[step]]

--- a/tests/testthat/test-salmon.R
+++ b/tests/testthat/test-salmon.R
@@ -1,4 +1,5 @@
 test_that('salmon and getSalmonMetadata', {
+  skip_if((!missingCommands[command == 'salmon',]$exists | !missingCommands[command == 'salmon_index',]$exists), 'Missing salmon command and/or index, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'salmon'
   paramsNow = params[[step]]

--- a/tests/testthat/test-salmon.R
+++ b/tests/testthat/test-salmon.R
@@ -1,5 +1,5 @@
 test_that('salmon and getSalmonMetadata', {
-  skip_if((!commandsDt[filename == 'salmon']$exists | !commandsDt[filename == 'salmon_index']$exists), 'Missing salmon command and/or index, skipping.')
+  skip_if((!commandsDt[filename == 'salmon']$exists || !commandsDt[filename == 'salmon_index']$exists), 'Missing salmon command and/or index, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'salmon'
   paramsNow = params[[step]]

--- a/tests/testthat/test-salmon.R
+++ b/tests/testthat/test-salmon.R
@@ -1,5 +1,5 @@
 test_that('salmon and getSalmonMetadata', {
-  skip_if((!commandsDt[command == 'salmon',]$exists | !commandsDt[command == 'salmon_index',]$exists), 'Missing salmon command and/or index, skipping.')
+  skip_if((!commandsDt[filename == 'salmon',]$exists | !commandsDt[filename == 'salmon_index',]$exists), 'Missing salmon command and/or index, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'salmon'
   paramsNow = params[[step]]

--- a/tests/testthat/test-salmon.R
+++ b/tests/testthat/test-salmon.R
@@ -1,5 +1,5 @@
 test_that('salmon and getSalmonMetadata', {
-  skip_if((!commandsDt[filename == 'salmon',]$exists | !commandsDt[filename == 'salmon_index',]$exists), 'Missing salmon command and/or index, skipping.')
+  skip_if((!commandsDt[filename == 'salmon']$exists | !commandsDt[filename == 'salmon_index']$exists), 'Missing salmon command and/or index, skipping.')
   skip_on_os('windows', arch = NULL)
   step = 'salmon'
   paramsNow = params[[step]]

--- a/tests/testthat/test-seeker.R
+++ b/tests/testthat/test-seeker.R
@@ -1,4 +1,5 @@
 test_that('seeker', {
+  skip_if(anyMissing, 'Missing required system dependencies, skipping.')
   skip_on_os('windows', arch = NULL)
 
   parentDirSeeker = file.path(dataDir, 'staging_seeker')
@@ -34,6 +35,7 @@ test_that('seeker skip all', {
 })
 
 test_that('checkSeekerArgs', {
+  skip_if(anyMissing, 'Missing required system dependencies, skipping.')
   skip_on_os('windows', arch = NULL)
   outputDirObs = checkSeekerArgs(params, parentDir)
   expect_equal(outputDirObs, outputDir)


### PR DESCRIPTION
This skips tests if the commands aren't found. Used a modified version of your `assertCommand` function.