### PR TITLE
1.0.5 cran revisions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,19 +8,19 @@ Authors@R: c(
 Description: Wrapper around various existing tools and command-line interfaces,
   providing a standard interface, simple parallelization, and detailed logging.
   For microarray data, maps probe sets to standard gene IDs, building on
-  GEOquery (Davis and Meltzer 2007, doi: 10.1093/bioinformatics/btm254),
-  ArrayExpress (Kauffmann et al. 2009, doi: 10.1093/bioinformatics/btp354),
-  RMA (Irizarry et al. 2003, doi: 10.1093/biostatistics/4.2.249), and
-  BrainArray (Dai et al. 2005, doi: 10.1093/nar/gni179).
+  GEOquery (Davis and Meltzer 2007, <doi:10.1093/bioinformatics/btm254>),
+  ArrayExpress (Kauffmann et al. 2009, <doi:10.1093/bioinformatics/btp354>),
+  RMA (Irizarry et al. 2003, <doi:10.1093/biostatistics/4.2.249>), and
+  BrainArray (Dai et al. 2005, <doi:10.1093/nar/gni179>).
   For RNA-seq data, fetches metadata and raw reads from NCBI SRA,
-  performs standard adapter and quality trimming using Trim Galore (Krueger, https://github.com/FelixKrueger/TrimGalore),
-  performs quality control checks using FastQC (Andrews, https://github.com/s-andrews/FastQC),
-  quantifies transcript abundances using salmon (Patro et al. 2017, doi: 10.1038/nmeth.4197) and potentially
-  refgenie (Stolarczyk et al. 2020, doi: 10.1093/gigascience/giz149),
-  aggregates the results using MultiQC (Ewels et al. 2016, doi: 10.1093/bioinformatics/btw354),
-  maps transcripts to genes using biomaRt (Durinkck et al. 2009, doi: 10.1038/nprot.2009.97),
+  performs standard adapter and quality trimming using Trim Galore (Krueger, <https://github.com/FelixKrueger/TrimGalore>),
+  performs quality control checks using FastQC (Andrews, <https://github.com/s-andrews/FastQC>),
+  quantifies transcript abundances using salmon (Patro et al. 2017, <doi:10.1038/nmeth.4197>) and potentially
+  refgenie (Stolarczyk et al. 2020, <doi:10.1093/gigascience/giz149>),
+  aggregates the results using MultiQC (Ewels et al. 2016, <doi:10.1093/bioinformatics/btw354>),
+  maps transcripts to genes using biomaRt (Durinkck et al. 2009, <doi:10.1038/nprot.2009.97>),
   and summarizes transcript-level quantifications for gene-level analyses using
-  tximport (Soneson et al. 2015, doi: 10.12688/f1000research.7563.2).
+  tximport (Soneson et al. 2015, <doi:10.12688/f1000research.7563.2>).
 URL: https://seeker.hugheylab.org, https://github.com/hugheylab/seeker
 License: GPL-2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,26 @@
 Package: seeker
 Type: Package
-Title: Process Genomic Data
+Title: Simplified fetching and processing of microarray and RNA-seq data.
 Version: 1.0.8
 Authors@R: c(
   person('Jake', 'Hughey', , 'jakejhughey@gmail.com', role = c('aut', 'cre')),
   person('Josh', 'Schoenbachler', , 'josh.schoenbachler@gmail.com', role = 'aut'))
-Description: Simplified processing of sequencing and microarray data.
+Description: Wrapper around various existing tools and command-line interfaces,
+  providing a standard interface, simple parallelization, and detailed logging.
+  For microarray data, maps probe sets to standard gene IDs, building on
+  GEOquery (Davis and Meltzer 2007, doi: 10.1093/bioinformatics/btm254),
+  ArrayExpress (Kauffmann et al. 2009, doi: 10.1093/bioinformatics/btp354),
+  RMA (Irizarry et al. 2003, doi: 10.1093/biostatistics/4.2.249), and
+  BrainArray (Dai et al. 2005, doi: 10.1093/nar/gni179).
+  For RNA-seq data, fetches metadata and raw reads from NCBI SRA,
+  performs standard adapter and quality trimming using Trim Galore (Krueger, https://github.com/FelixKrueger/TrimGalore),
+  performs quality control checks using FastQC (Andrews, https://github.com/s-andrews/FastQC),
+  quantifies transcript abundances using salmon (Patro et al. 2017, doi: 10.1038/nmeth.4197) and potentially
+  refgenie (Stolarczyk et al. 2020, doi: 10.1093/gigascience/giz149),
+  aggregates the results using MultiQC (Ewels et al. 2016, doi: 10.1093/bioinformatics/btw354),
+  maps transcripts to genes using biomaRt (Durinkck et al. 2009, doi: 10.1038/nprot.2009.97),
+  and summarizes transcript-level quantifications for gene-level analyses using
+  tximport (Soneson et al. 2015, doi: 10.12688/f1000research.7563.2).
 URL: https://seeker.hugheylab.org, https://github.com/hugheylab/seeker
 License: GPL-2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: seeker
 Type: Package
 Title: Process Genomic Data
-Version: 1.0.7
+Version: 1.0.8
 Authors@R: c(
   person('Jake', 'Hughey', , 'jakejhughey@gmail.com', role = c('aut', 'cre')),
   person('Josh', 'Schoenbachler', , 'josh.schoenbachler@gmail.com', role = 'aut'))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# seeker 1.0.8
+* Remove default install directories for dependencies in `installSysDeps()`.
+* Replaced `options(warn=-1)` to use `suppressWarnings()`.
+* Updated description text.
+* Revised console printing.
+
 # seeker 1.0.7
 * Added support for more platforms.
 * Added ability for `seekerArray()` to skip processing the expression data.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # seeker 1.0.8
-* Remove default install directories for dependencies in `installSysDeps()`.
+* Removed default install directories for dependencies in `installSysDeps()`.
 * Replaced `options(warn=-1)` to use `suppressWarnings()`.
 * Updated description text.
 * Revised console printing.

--- a/R/install_sys_deps.R
+++ b/R/install_sys_deps.R
@@ -17,10 +17,10 @@ installSraToolkit = function(installDir, rprofileDir) {
 
   # Check if sratoolkit already exists at location
   if (dir.exists(sraPath)) {
-    cat('SRA Toolkit already installed, skipping...\n')
+    message('SRA Toolkit already installed, skipping...\n')
 
   } else {
-    cat('Installing SRA Toolkit...\n')
+    message('Installing SRA Toolkit...\n')
     # Change working directory
     withr::local_dir(installDir)
 
@@ -72,10 +72,10 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
     file.path(minicondaPath, 'envs', minicondaEnv)}
 
   if (dir.exists(minicondaPath)) {
-    cat('Miniconda already installed, skipping...\n')
+    message('Miniconda already installed, skipping...\n')
 
   } else {
-    cat('Installing Miniconda...\n')
+    message('Installing Miniconda...\n')
 
     miniOsSh = if (Sys.info()[['sysname']] == 'Darwin') 'MacOSX' else 'Linux'
     miniSh = glue('Miniconda3-latest-{miniOsSh}-x86_64.sh')
@@ -84,12 +84,12 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
       glue('https://repo.anaconda.com/miniconda/{miniSh}'), miniSh, quiet = TRUE)
     system2('sh', c(miniSh, '-b', '-p', file.path(installDir, 'miniconda3')))
 
-    cat('Running conda init...\n')
+    message('Running conda init...\n')
     system(glue('{minicondaPath}/bin/conda init bash'))}
 
   # Create new environment if it doesn't exist
   if (minicondaEnv != 'base' && !dir.exists(minicondaEnvPath)) {
-    cat('Creating conda environment...\n')
+    message('Creating conda environment...\n')
     yamlPath = system.file('extdata', 'conda_env.yml', package = 'seeker')
     envYaml = yaml::read_yaml(yamlPath)
 
@@ -106,7 +106,7 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
     glue('options(seeker.miniconda = "{minicondaEnvPath}")'), rprofileDir, 'R')
   options(seeker.miniconda = minicondaEnvPath)#}
 
-  cat('Installing conda packages via mamba...\n')
+  message('Installing conda packages via mamba...\n')
   mambaEnvPath = system.file('extdata', 'mamba_env.yml', package = 'seeker')
   mambaArgs = c('env', 'update', '-p', minicondaEnvPath, '--file', mambaEnvPath)
   system3('mamba', mambaArgs)
@@ -115,7 +115,7 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
 
 
 setRefgenie = function(refgenieDir, rprofileDir) {
-  cat('Configuring refgenie...\n')
+  message('Configuring refgenie...\n')
   if (!dir.exists(refgenieDir)) dir.create(refgenieDir)
   refgenieYamlPath = file.path(path.expand(refgenieDir), 'genome_config.yaml')
   if (!file.exists(refgenieYamlPath)) {
@@ -128,7 +128,7 @@ setRefgenie = function(refgenieDir, rprofileDir) {
 
 
 getRefgenieGenomes = function(genomes) {
-  cat('Fetching refgenie genome assets...\n')
+  message('Fetching refgenie genome assets...\n')
   for (genome in genomes) {
     rgArgs = c('pull', genome, '--genome-config', Sys.getenv('REFGENIE'))
     system3('refgenie', rgArgs)}
@@ -228,7 +228,7 @@ installSysDeps = function(
     if (is.na(validateCommand('fastq_screen'))) {
       warning('fastq_screen not found, genomes cannot be fetched.')
     } else {
-      cat('Fetching fastq_screen genomes...\n')
+      message('Fetching fastq_screen genomes...\n')
       if (!dir.exists(fastqscreenDir)) dir.create(fastqscreenDir)
       tryCatch(
         system3('fastq_screen', c('--get_genomes', '--outdir', fastqscreenDir)),

--- a/R/install_sys_deps.R
+++ b/R/install_sys_deps.R
@@ -158,19 +158,15 @@ getSysDeps = function(outputDir, params) {
 #' seeker to fetch and process RNA-seq data.
 #'
 #' @param sraToolkitDir String indicating directory in which to install the
-#'   [SRA Toolkit](https://github.com/ncbi/sra-tools). If `NULL`, the Toolkit
-#'   will not be installed. No default is provided, but it is recommended that
-#'   you use the `~` (home) directory.
+#'   [SRA Toolkit](https://github.com/ncbi/sra-tools). Recommended to use "~",
+#'   the home directory. If `NULL`, the Toolkit will not be installed.
 #' @param minicondaDir String indicating directory in which to install
-#'   [Miniconda](https://docs.conda.io/en/latest/miniconda.html). If `NULL`,
-#'   Miniconda will not be installed. No default is provided, but it is
-#'   recommended that you use the `~` (home)
-#'   directory.
-#' @param refgenieDir String indicating directory in which to download genome
-#'   assets using refgenie. Only used if `minicondaDir` is not `NULL`. If the
-#'   directory does not end with `refgenie_genomes` it will be appended. No
-#'   default is provided, but it is
-#'   recommended that you use the `~` (home) directory.
+#'   [Miniconda](https://docs.conda.io/en/latest/miniconda.html). Recommended
+#'   to use "~", the home directory. If `NULL`, Miniconda will not be installed.
+#' @param refgenieDir String indicating directory in which to store the
+#'   directory of genome assets from refgenie, which will be named
+#'   "refgenie_genomes". Recommended to use "~", the home directory. Only used
+#'   if `minicondaDir` is not `NULL`.
 #' @param rprofileDir String indicating directory in which to create or modify
 #'   .Rprofile, which is run by R on startup. Common options are "~" or ".".
 #' @param minicondaEnv String indicating name of the Miniconda environment in
@@ -200,7 +196,6 @@ installSysDeps = function(
   if (!is.null(minicondaDir)) assertDirectoryExists(minicondaDir)
   assertString(minicondaEnv, pattern = '^\\S+$')
   assertString(refgenieDir, null.ok = is.null(minicondaDir))
-  refgenieDir = file.path(refgenieDir, 'refgenie_genomes')
   assertCharacter(refgenieGenomes, any.missing = FALSE, null.ok = TRUE)
   assertString(fastqscreenDir, null.ok = TRUE)
   assertString(rprofileDir)
@@ -215,7 +210,8 @@ installSysDeps = function(
     if (is.na(validateCommand('refgenie'))) {
       warning('refgenie not found, cannot be configured.')
     } else {
-      tryCatch(setRefgenie(refgenieDir, rprofileDir), error = warning)}}
+      rgDir = file.path(refgenieDir, 'refgenie_genomes')
+      tryCatch(setRefgenie(rgDir, rprofileDir), error = warning)}}
 
   if (!is.null(refgenieGenomes)) {
     if (is.na(validateCommand('refgenie'))) {

--- a/R/install_sys_deps.R
+++ b/R/install_sys_deps.R
@@ -17,10 +17,10 @@ installSraToolkit = function(installDir, rprofileDir) {
 
   # Check if sratoolkit already exists at location
   if (dir.exists(sraPath)) {
-    message('SRA Toolkit already installed, skipping...\n')
+    message('SRA Toolkit already installed, skipping...')
 
   } else {
-    message('Installing SRA Toolkit...\n')
+    message('Installing SRA Toolkit...')
     # Change working directory
     withr::local_dir(installDir)
 
@@ -55,7 +55,7 @@ installSraToolkit = function(installDir, rprofileDir) {
     writeLines(lines, configPath)}
 
   # Add to OS path and .Rprofile path
-  addToProfile(glue('export PATH="$PATH:{sraPath}"'), rprofileDir)
+  addToProfile(glue('export PATH="$PATH:{sraPath}"'))
   path = paste(Sys.getenv('PATH'), sraPath, sep = ':')
   addToProfile(glue('Sys.setenv(PATH = "{path}")'), rprofileDir, 'R')
   Sys.setenv(PATH = path)
@@ -72,10 +72,10 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
     file.path(minicondaPath, 'envs', minicondaEnv)}
 
   if (dir.exists(minicondaPath)) {
-    message('Miniconda already installed, skipping...\n')
+    message('Miniconda already installed, skipping...')
 
   } else {
-    message('Installing Miniconda...\n')
+    message('Installing Miniconda...')
 
     miniOsSh = if (Sys.info()[['sysname']] == 'Darwin') 'MacOSX' else 'Linux'
     miniSh = glue('Miniconda3-latest-{miniOsSh}-x86_64.sh')
@@ -84,12 +84,12 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
       glue('https://repo.anaconda.com/miniconda/{miniSh}'), miniSh, quiet = TRUE)
     system2('sh', c(miniSh, '-b', '-p', file.path(installDir, 'miniconda3')))
 
-    message('Running conda init...\n')
+    message('Running conda init...')
     system(glue('{minicondaPath}/bin/conda init bash'))}
 
   # Create new environment if it doesn't exist
   if (minicondaEnv != 'base' && !dir.exists(minicondaEnvPath)) {
-    message('Creating conda environment...\n')
+    message('Creating conda environment...')
     yamlPath = system.file('extdata', 'conda_env.yml', package = 'seeker')
     envYaml = yaml::read_yaml(yamlPath)
 
@@ -106,7 +106,7 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
     glue('options(seeker.miniconda = "{minicondaEnvPath}")'), rprofileDir, 'R')
   options(seeker.miniconda = minicondaEnvPath)#}
 
-  message('Installing conda packages via mamba...\n')
+  message('Installing conda packages via mamba...')
   mambaEnvPath = system.file('extdata', 'mamba_env.yml', package = 'seeker')
   mambaArgs = c('env', 'update', '-p', minicondaEnvPath, '--file', mambaEnvPath)
   system3('mamba', mambaArgs)
@@ -115,12 +115,12 @@ installMiniconda = function(installDir, minicondaEnv, rprofileDir) {
 
 
 setRefgenie = function(refgenieDir, rprofileDir) {
-  message('Configuring refgenie...\n')
+  message('Configuring refgenie...')
   if (!dir.exists(refgenieDir)) dir.create(refgenieDir)
   refgenieYamlPath = file.path(path.expand(refgenieDir), 'genome_config.yaml')
   if (!file.exists(refgenieYamlPath)) {
     system3('refgenie', c('init', '-c', refgenieYamlPath))}
-  addToProfile(glue('export REFGENIE="{refgenieYamlPath}"'), rprofileDir)
+  addToProfile(glue('export REFGENIE="{refgenieYamlPath}"'))
   addToProfile(
     glue('Sys.setenv(REFGENIE = "{refgenieYamlPath}")'), rprofileDir, 'R')
   Sys.setenv(REFGENIE = refgenieYamlPath)
@@ -128,7 +128,7 @@ setRefgenie = function(refgenieDir, rprofileDir) {
 
 
 getRefgenieGenomes = function(genomes) {
-  message('Fetching refgenie genome assets...\n')
+  message('Fetching refgenie genome assets...')
   for (genome in genomes) {
     rgArgs = c('pull', genome, '--genome-config', Sys.getenv('REFGENIE'))
     system3('refgenie', rgArgs)}
@@ -159,17 +159,17 @@ getSysDeps = function(outputDir, params) {
 #'
 #' @param sraToolkitDir String indicating directory in which to install the
 #'   [SRA Toolkit](https://github.com/ncbi/sra-tools). If `NULL`, the Toolkit
-#'   will not be installed. Due to CRAN policies, we cannot provide a default for
-#'   this argument, but it is recommended that you use the `~` (home) directory.
+#'   will not be installed. No default is provided, but it is recommended that
+#'   you use the `~` (home) directory.
 #' @param minicondaDir String indicating directory in which to install
 #'   [Miniconda](https://docs.conda.io/en/latest/miniconda.html). If `NULL`,
-#'   Miniconda will not be installed. Due to CRAN policies, we cannot provide a
-#'   default for this argument, but it is recommended that you use the `~` (home)
+#'   Miniconda will not be installed. No default is provided, but it is
+#'   recommended that you use the `~` (home)
 #'   directory.
 #' @param refgenieDir String indicating directory in which to download genome
 #'   assets using refgenie. Only used if `minicondaDir` is not `NULL`. If the
-#'   directory does not end with `refgenie_genomes` it will be appended. Due to
-#'   CRAN policies, we cannot provide a default for this argument, but it is
+#'   directory does not end with `refgenie_genomes` it will be appended. No
+#'   default is provided, but it is
 #'   recommended that you use the `~` (home) directory.
 #' @param rprofileDir String indicating directory in which to create or modify
 #'   .Rprofile, which is run by R on startup. Common options are "~" or ".".
@@ -200,8 +200,7 @@ installSysDeps = function(
   if (!is.null(minicondaDir)) assertDirectoryExists(minicondaDir)
   assertString(minicondaEnv, pattern = '^\\S+$')
   assertString(refgenieDir, null.ok = is.null(minicondaDir))
-  if (!is.null(refgenieDir) && !endsWith(refgenieDir, 'refgenie_genomes')) {
-    refgenieDir = file.path(refgenieDir, 'refgenie_genomes')}
+  refgenieDir = file.path(refgenieDir, 'refgenie_genomes')
   assertCharacter(refgenieGenomes, any.missing = FALSE, null.ok = TRUE)
   assertString(fastqscreenDir, null.ok = TRUE)
   assertString(rprofileDir)
@@ -228,7 +227,7 @@ installSysDeps = function(
     if (is.na(validateCommand('fastq_screen'))) {
       warning('fastq_screen not found, genomes cannot be fetched.')
     } else {
-      message('Fetching fastq_screen genomes...\n')
+      message('Fetching fastq_screen genomes...')
       if (!dir.exists(fastqscreenDir)) dir.create(fastqscreenDir)
       tryCatch(
         system3('fastq_screen', c('--get_genomes', '--outdir', fastqscreenDir)),

--- a/R/seeker.R
+++ b/R/seeker.R
@@ -362,8 +362,9 @@ seeker = function(params, parentDir = '.', dryRun = FALSE) {
     } else {
       sprintf('Dry run encountered the following errors:\n%s\n',
               paste(coll$getMessages(), collapse = '\n'))}
+    message(m)
     writeLines(m, 'seeker_dry_run.log')
-    return(m)}
+    return(invisible())}
 
   outputDir = checkArgsRes$outputDir
   if (!dir.exists(outputDir)) dir.create(outputDir)

--- a/R/seeker.R
+++ b/R/seeker.R
@@ -362,9 +362,8 @@ seeker = function(params, parentDir = '.', dryRun = FALSE) {
     } else {
       sprintf('Dry run encountered the following errors:\n%s\n',
               paste(coll$getMessages(), collapse = '\n'))}
-    cat(m)
     writeLines(m, 'seeker_dry_run.log')
-    return(invisible())}
+    return(m)}
 
   outputDir = checkArgsRes$outputDir
   if (!dir.exists(outputDir)) dir.create(outputDir)

--- a/R/seeker.R
+++ b/R/seeker.R
@@ -358,9 +358,9 @@ seeker = function(params, parentDir = '.', dryRun = FALSE) {
 
   if (dryRun) {
     m = if (length(coll$getMessages()) == 0) {
-      'Dry run encountered no errors. All systems go.\n'
+      'Dry run encountered no errors. All systems go.'
     } else {
-      sprintf('Dry run encountered the following errors:\n%s\n',
+      sprintf('Dry run encountered the following errors:\n%s',
               paste(coll$getMessages(), collapse = '\n'))}
     message(m)
     writeLines(m, 'seeker_dry_run.log')

--- a/R/utils.R
+++ b/R/utils.R
@@ -151,8 +151,9 @@ validateCommand = function(cmd) {
   # give warning on mac and error on linux
   old = getOption('warn')
   options(warn = -1)
-  path = tryCatch({system3('command', c('-v', safe(cmd)), stdout = TRUE)},
-                  error = function(e) NA_character_)
+  suppressWarnings({
+    path = tryCatch({system3('command', c('-v', safe(cmd)), stdout = TRUE)},
+                    error = function(e) NA_character_)})
   options(warn = old)
   if (length(path) == 0) path = NA_character_
   return(path)}

--- a/man/installSysDeps.Rd
+++ b/man/installSysDeps.Rd
@@ -17,19 +17,19 @@ installSysDeps(
 \arguments{
 \item{sraToolkitDir}{String indicating directory in which to install the
 \href{https://github.com/ncbi/sra-tools}{SRA Toolkit}. If \code{NULL}, the Toolkit
-will not be installed. Due to CRAN policies, we cannot provide a default for
-this argument, but it is recommended that you use the \code{~} (home) directory.}
+will not be installed. No default is provided, but it is recommended that
+you use the \code{~} (home) directory.}
 
 \item{minicondaDir}{String indicating directory in which to install
 \href{https://docs.conda.io/en/latest/miniconda.html}{Miniconda}. If \code{NULL},
-Miniconda will not be installed. Due to CRAN policies, we cannot provide a
-default for this argument, but it is recommended that you use the \code{~} (home)
+Miniconda will not be installed. No default is provided, but it is
+recommended that you use the \code{~} (home)
 directory.}
 
 \item{refgenieDir}{String indicating directory in which to download genome
 assets using refgenie. Only used if \code{minicondaDir} is not \code{NULL}. If the
-directory does not end with \code{refgenie_genomes} it will be appended. Due to
-CRAN policies, we cannot provide a default for this argument, but it is
+directory does not end with \code{refgenie_genomes} it will be appended. No
+default is provided, but it is
 recommended that you use the \code{~} (home) directory.}
 
 \item{rprofileDir}{String indicating directory in which to create or modify

--- a/man/installSysDeps.Rd
+++ b/man/installSysDeps.Rd
@@ -5,30 +5,39 @@
 \title{Install seeker's system dependencies}
 \usage{
 installSysDeps(
-  sraToolkitDir = "~",
-  minicondaDir = "~",
+  sraToolkitDir,
+  minicondaDir,
+  refgenieDir,
+  rprofileDir,
   minicondaEnv = "seeker",
-  refgenieDir = "~/refgenie_genomes",
   refgenieGenomes = NULL,
-  fastqscreenDir = NULL,
-  rprofileDir = "~"
+  fastqscreenDir = NULL
 )
 }
 \arguments{
 \item{sraToolkitDir}{String indicating directory in which to install the
 \href{https://github.com/ncbi/sra-tools}{SRA Toolkit}. If \code{NULL}, the Toolkit
-will not be installed.}
+will not be installed. Due to CRAN policies, we cannot provide a default for
+this argument, but it is recommended that you use the \code{~} (home) directory.}
 
 \item{minicondaDir}{String indicating directory in which to install
 \href{https://docs.conda.io/en/latest/miniconda.html}{Miniconda}. If \code{NULL},
-Miniconda will not be installed.}
+Miniconda will not be installed. Due to CRAN policies, we cannot provide a
+default for this argument, but it is recommended that you use the \code{~} (home)
+directory.}
+
+\item{refgenieDir}{String indicating directory in which to download genome
+assets using refgenie. Only used if \code{minicondaDir} is not \code{NULL}. If the
+directory does not end with \code{refgenie_genomes} it will be appended. Due to
+CRAN policies, we cannot provide a default for this argument, but it is
+recommended that you use the \code{~} (home) directory.}
+
+\item{rprofileDir}{String indicating directory in which to create or modify
+.Rprofile, which is run by R on startup. Common options are "~" or ".".}
 
 \item{minicondaEnv}{String indicating name of the Miniconda environment in
 which to install various conda packages (fastq-screen, fastqc, multiqc,
 pigz, refgenie, salmon, and trim-galore).}
-
-\item{refgenieDir}{String indicating directory in which to download genome
-assets using refgenie. Only used if \code{minicondaDir} is not \code{NULL}.}
 
 \item{refgenieGenomes}{Character vector indicating genome assets, such as
 transcriptome indexes for \code{\link[=salmon]{salmon()}}, to pull from
@@ -38,9 +47,6 @@ transcriptome indexes for \code{\link[=salmon]{salmon()}}, to pull from
 \item{fastqscreenDir}{String indicating directory in which to download the
 genomes for \code{\link[=fastqscreen]{fastqscreen()}}. This takes a long time. If \code{NULL}, genomes are
 not downloaded.}
-
-\item{rprofileDir}{String indicating directory in which to create or modify
-.Rprofile, which is run by R on startup. Common options are "~" or ".".}
 }
 \value{
 \code{NULL}, invisibly

--- a/man/installSysDeps.Rd
+++ b/man/installSysDeps.Rd
@@ -16,21 +16,17 @@ installSysDeps(
 }
 \arguments{
 \item{sraToolkitDir}{String indicating directory in which to install the
-\href{https://github.com/ncbi/sra-tools}{SRA Toolkit}. If \code{NULL}, the Toolkit
-will not be installed. No default is provided, but it is recommended that
-you use the \code{~} (home) directory.}
+\href{https://github.com/ncbi/sra-tools}{SRA Toolkit}. Recommended to use "~",
+the home directory. If \code{NULL}, the Toolkit will not be installed.}
 
 \item{minicondaDir}{String indicating directory in which to install
-\href{https://docs.conda.io/en/latest/miniconda.html}{Miniconda}. If \code{NULL},
-Miniconda will not be installed. No default is provided, but it is
-recommended that you use the \code{~} (home)
-directory.}
+\href{https://docs.conda.io/en/latest/miniconda.html}{Miniconda}. Recommended
+to use "~", the home directory. If \code{NULL}, Miniconda will not be installed.}
 
-\item{refgenieDir}{String indicating directory in which to download genome
-assets using refgenie. Only used if \code{minicondaDir} is not \code{NULL}. If the
-directory does not end with \code{refgenie_genomes} it will be appended. No
-default is provided, but it is
-recommended that you use the \code{~} (home) directory.}
+\item{refgenieDir}{String indicating directory in which to store the
+directory of genome assets from refgenie, which will be named
+"refgenie_genomes". Recommended to use "~", the home directory. Only used
+if \code{minicondaDir} is not \code{NULL}.}
 
 \item{rprofileDir}{String indicating directory in which to create or modify
 .Rprofile, which is run by R on startup. Common options are "~" or ".".}


### PR DESCRIPTION
Addresses issue https://github.com/hugheylab/seeker/issues/37 except for the description text.

@jakejh I made the seeker function return the dry run result instead of printing using `cat()`, but for the system dependency functions I revised them to use the `message()` function and keep the message logging. Let me know if you want to take a different approach!